### PR TITLE
Stopped disabling some pylint errors

### DIFF
--- a/tests/tests.pylintrc
+++ b/tests/tests.pylintrc
@@ -1,5 +1,5 @@
 [basic]
-disable=missing-docstring, unsubscriptable-object, no-self-use, unsupported-membership-test, too-many-arguments
+disable=missing-docstring, no-self-use, too-many-arguments
 
 [design]
 min-public-methods=1


### PR DESCRIPTION
Stopped disabling unsubscriptable-object and unsupported-membership-test errors in pylint. They were raised because of a pylint/astroid bug, which seems to be fixed now. More info: https://github.com/PyCQA/pylint/issues/2605#issuecomment-544788482