### PR TITLE
Added `parse_mode` support for responses

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,5 @@
 [basic]
-disable=missing-docstring
+disable=missing-docstring, fixme
 
 [design]
 min-public-methods=1

--- a/gramhopper/configuration/trigger_or_response_parser.py
+++ b/gramhopper/configuration/trigger_or_response_parser.py
@@ -39,6 +39,8 @@ class TriggerOrResponseParser(abc.ABC):
 
         # Some triggers (most of them) are classes and some are instances (mostly filter triggers).
         # This allows both cases to be used.
+        # TODO: this comment does not seem to be correct any more.
+        #  Try to remove the case outside the "if" block; All triggers and responses seem to be classes.
         if isclass(element):
             trigger_or_response = element(**config_copy)
             if name:

--- a/gramhopper/configuration/trigger_or_response_parser.py
+++ b/gramhopper/configuration/trigger_or_response_parser.py
@@ -39,8 +39,8 @@ class TriggerOrResponseParser(abc.ABC):
 
         # Some triggers (most of them) are classes and some are instances (mostly filter triggers).
         # This allows both cases to be used.
-        # TODO: this comment does not seem to be correct any more.
-        #  Try to remove the case outside the "if" block; All triggers and responses seem to be classes.
+        # TODO: this comment does not seem to be correct any more. Try removing the case outside
+        #  the "if" block; All triggers and responses seem to be classes.
         if isclass(element):
             trigger_or_response = element(**config_copy)
             if name:

--- a/gramhopper/responses/basic_responses.py
+++ b/gramhopper/responses/basic_responses.py
@@ -1,10 +1,24 @@
 import abc
+from typing import Optional, Dict, Any
+
 from telegram import Bot, Update
 from telegram.message import Message
 from ..representable import Representable
 
 
 class BaseResponse(abc.ABC, Representable):
+    def __init__(self, parse_mode: Optional[str] = None):
+        super().__init__()
+        self.__parse_mode = parse_mode
+
+    @property
+    def response_helper_kwargs(self) -> Dict[str, Any]:
+        kwargs = {}
+
+        if self.__parse_mode is not None:
+            kwargs["parse_mode"] = self.__parse_mode
+
+        return kwargs
 
     @abc.abstractmethod
     def respond(self, bot: Bot, update: Update, response_payload: dict) -> Message:

--- a/gramhopper/responses/match_responses.py
+++ b/gramhopper/responses/match_responses.py
@@ -19,7 +19,8 @@ class _MatchTextResponse(BaseResponse):
         Constructs the response.
 
         :param template: The template to use when building the response text
-        :param parse_mode: Optional parse mode for the message. Read more in :py:class:`telegram.ParseMode`.
+        :param parse_mode: Optional parse mode for the message. Read more in \
+            :py:class:`telegram.ParseMode`.
         """
         super().__init__(parse_mode)
         self.template = template

--- a/gramhopper/responses/match_responses.py
+++ b/gramhopper/responses/match_responses.py
@@ -1,4 +1,6 @@
 import abc
+from typing import Optional
+
 from telegram import Bot, Update
 from telegram.message import Message
 from ..dict_enum import DictEnum
@@ -12,13 +14,14 @@ class _MatchTextResponse(BaseResponse):
     handling the actual response action.
     """
 
-    def __init__(self, template: str):
+    def __init__(self, template: str, parse_mode: Optional[str] = None):
         """
         Constructs the response.
 
         :param template: The template to use when building the response text
+        :param parse_mode: Optional parse mode for the message. Read more in :py:class:`telegram.ParseMode`.
         """
-        super().__init__()
+        super().__init__(parse_mode)
         self.template = template
 
     @abc.abstractmethod
@@ -38,14 +41,24 @@ class _MatchMessageResponse(_MatchTextResponse):
     """A regexp-based response in which the response method is a normal message"""
 
     def respond(self, bot: Bot, update: Update, response_payload: dict) -> Message:
-        return ResponseHelper.message(bot, update, self.build_response_text(response_payload))
+        return ResponseHelper.message(
+            bot,
+            update,
+            self.build_response_text(response_payload),
+            **self.response_helper_kwargs,
+        )
 
 
 class _MatchReplyResponse(_MatchTextResponse):
     """A regexp-based response in which the response method is a reply to the triggering message"""
 
     def respond(self, bot: Bot, update: Update, response_payload: dict) -> Message:
-        return ResponseHelper.reply(bot, update, self.build_response_text(response_payload))
+        return ResponseHelper.reply(
+            bot,
+            update,
+            self.build_response_text(response_payload),
+            **self.response_helper_kwargs,
+        )
 
 
 class MatchResponses(DictEnum):

--- a/gramhopper/responses/preset_responses.py
+++ b/gramhopper/responses/preset_responses.py
@@ -19,7 +19,8 @@ class _PresetTextResponse(BaseResponse):
         Constructs the response.
 
         :param preset_response: The preset response or list of responses
-        :param parse_mode: Optional parse mode for the message. Read more in :py:class:`telegram.ParseMode`.
+        :param parse_mode: Optional parse mode for the message. Read more in \
+            :py:class:`telegram.ParseMode`.
         """
         super().__init__(parse_mode)
         self.preset_responses = preset_response
@@ -50,26 +51,42 @@ class _PresetDocumentResponse(BaseResponse):
         Constructs the response.
 
         :param preset_response: The preset document URL or document object
-        :param parse_mode: Optional parse mode for the message. Read more in :py:class:`telegram.ParseMode`.
+        :param parse_mode: Optional parse mode for the message. Read more in \
+            :py:class:`telegram.ParseMode`.
         """
         super().__init__(parse_mode)
         self.preset_response = preset_response
 
     def respond(self, bot: Bot, update: Update, response_payload: dict) -> Message:
-        return ResponseHelper.document(bot, update, self.preset_response, **self.response_helper_kwargs)
+        return ResponseHelper.document(
+            bot,
+            update,
+            self.preset_response,
+            **self.response_helper_kwargs,
+        )
 
 
 class _PresetMessageResponse(_PresetTextResponse):
     """A preset response in which the response method is a normal message"""
 
     def respond(self, bot: Bot, update: Update, response_payload: dict) -> Message:
-        return ResponseHelper.message(bot, update, self.get_response_text(), **self.response_helper_kwargs)
+        return ResponseHelper.message(
+            bot,
+            update,
+            self.get_response_text(),
+            **self.response_helper_kwargs,
+        )
 
 
 class _PresetReplyResponse(_PresetTextResponse):
     """A preset response in which the response method is a reply to the triggering message"""
     def respond(self, bot: Bot, update: Update, response_payload: dict) -> Message:
-        return ResponseHelper.reply(bot, update, self.get_response_text(), **self.response_helper_kwargs)
+        return ResponseHelper.reply(
+            bot,
+            update,
+            self.get_response_text(),
+            **self.response_helper_kwargs,
+        )
 
 
 class PresetResponses(DictEnum):

--- a/gramhopper/responses/preset_responses.py
+++ b/gramhopper/responses/preset_responses.py
@@ -1,6 +1,6 @@
 import abc
 import random
-from typing import Union, List
+from typing import Union, List, Optional
 from telegram import Bot, Update, Document
 from telegram.message import Message
 from ..dict_enum import DictEnum
@@ -14,13 +14,14 @@ class _PresetTextResponse(BaseResponse):
     handling the actual response action.
     """
 
-    def __init__(self, preset_response: Union[str, List[str]]):
+    def __init__(self, preset_response: Union[str, List[str]], parse_mode: Optional[str] = None):
         """
         Constructs the response.
 
         :param preset_response: The preset response or list of responses
+        :param parse_mode: Optional parse mode for the message. Read more in :py:class:`telegram.ParseMode`.
         """
-        super().__init__()
+        super().__init__(parse_mode)
         self.preset_responses = preset_response
 
     @abc.abstractmethod
@@ -44,30 +45,31 @@ class _PresetTextResponse(BaseResponse):
 class _PresetDocumentResponse(BaseResponse):
     """A preset response in which the response method is a document"""
 
-    def __init__(self, preset_response: Union[str, Document]):
+    def __init__(self, preset_response: Union[str, Document], parse_mode: Optional[str] = None):
         """
         Constructs the response.
 
         :param preset_response: The preset document URL or document object
+        :param parse_mode: Optional parse mode for the message. Read more in :py:class:`telegram.ParseMode`.
         """
-        super().__init__()
+        super().__init__(parse_mode)
         self.preset_response = preset_response
 
     def respond(self, bot: Bot, update: Update, response_payload: dict) -> Message:
-        return ResponseHelper.document(bot, update, self.preset_response)
+        return ResponseHelper.document(bot, update, self.preset_response, **self.response_helper_kwargs)
 
 
 class _PresetMessageResponse(_PresetTextResponse):
     """A preset response in which the response method is a normal message"""
 
     def respond(self, bot: Bot, update: Update, response_payload: dict) -> Message:
-        return ResponseHelper.message(bot, update, self.get_response_text())
+        return ResponseHelper.message(bot, update, self.get_response_text(), **self.response_helper_kwargs)
 
 
 class _PresetReplyResponse(_PresetTextResponse):
     """A preset response in which the response method is a reply to the triggering message"""
     def respond(self, bot: Bot, update: Update, response_payload: dict) -> Message:
-        return ResponseHelper.reply(bot, update, self.get_response_text())
+        return ResponseHelper.reply(bot, update, self.get_response_text(), **self.response_helper_kwargs)
 
 
 class PresetResponses(DictEnum):

--- a/gramhopper/responses/response_helper.py
+++ b/gramhopper/responses/response_helper.py
@@ -5,15 +5,18 @@ from telegram.message import Message
 
 class ResponseHelper:
     @staticmethod
-    def reply(bot: Bot, update: Update, response: Any) -> Message:
-        return bot.send_message(chat_id=update.effective_chat.id,
-                                text=response,
-                                reply_to_message_id=update.message.message_id)
+    def reply(bot: Bot, update: Update, response: Any, **kwargs: Any) -> Message:
+        return bot.send_message(
+            chat_id=update.effective_chat.id,
+            text=response,
+            reply_to_message_id=update.message.message_id,
+            **kwargs,
+        )
 
     @staticmethod
-    def message(bot: Bot, update: Update, response: Any) -> Message:
-        return bot.send_message(chat_id=update.effective_chat.id, text=response)
+    def message(bot: Bot, update: Update, response: Any, **kwargs: Any) -> Message:
+        return bot.send_message(chat_id=update.effective_chat.id, text=response, **kwargs)
 
     @staticmethod
-    def document(bot: Bot, update: Update, response: Any) -> Message:
-        return bot.send_document(update.effective_chat.id, response)
+    def document(bot: Bot, update: Update, response: Any, **kwargs: Any) -> Message:
+        return bot.send_document(chat_id=update.effective_chat.id, document=response, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytype==2019.9.6
 pylint==2.3.1
 flake8==3.7.8
 pytest==5.1.2
+wheel==0.37.1


### PR DESCRIPTION
Added [`parse_mode`](https://python-telegram-bot.readthedocs.io/en/stable/telegram.parsemode.html#telegram.ParseMode) support.

Please review the commits separately - the first one is the actual logic change, and the last one only contains lint fixes. I will squash them anyway on merge.

Turns out Travis CI does not _automatically_ allow free usage for OSS projects (a project maintainer has to apply to get this), but I've run lint+test+build (incl. `build-docs`) locally, and will run publish locally when we're done and merged.